### PR TITLE
Add seeding stock movement state

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ enum StockMovementType {
   MOVEMENT
   SELL
   APLICATION
+  SEEDING
 }
 
 model StockMovement {

--- a/src/Stock/application/factories/States/Seeding.ts
+++ b/src/Stock/application/factories/States/Seeding.ts
@@ -1,0 +1,101 @@
+import WarehouseService from 'Stock/application/service/WarehouseService';
+import { CreateStockMovementDto } from 'Stock/infrastructure/dto/StockMovement/CreateStockMovementDto';
+import { AbstractStockMovement } from './AbstractStockMovement';
+import StockMovement from 'Stock/domain/models/StockMovement';
+import WarehouseDetailService from 'Stock/application/service/WarehouseDetailService';
+import WarehouseValidations from 'Stock/application/validations/WarehouseValidations';
+import WarehouseDetail from 'Stock/domain/models/WarehouseDetail';
+import InsufficientQuantityException from 'Stock/application/exception/InsufficientQuantityException';
+import ProductNotFoundToAplicationException from 'Stock/application/exception/ProductNotFoundToAplicationException';
+import BatchService from 'Stock/application/service/BatchService';
+import AplicatorService from 'Stock/application/service/AplicatorService';
+
+export class Seeding extends AbstractStockMovement {
+  warehouseDetailItems: WarehouseDetail[] = [];
+  constructor(
+    private readonly createStockMovementDto: CreateStockMovementDto,
+    private readonly warehouseService: WarehouseService,
+    private readonly warehouseDetailService: WarehouseDetailService,
+    private readonly batchService: BatchService,
+    private readonly aplicatorService: AplicatorService,
+    private readonly warehouseValidations: WarehouseValidations,
+  ) {
+    super(createStockMovementDto);
+  }
+
+  public async generateMovement(): Promise<StockMovement> {
+    const warehouseOrigin = await this.warehouseService.findWarehouseById(
+      this.createStockMovementDto.warehouseOriginId,
+    );
+
+    const batch = await this.batchService.findBatchById(
+      this.createStockMovementDto.batchId,
+    );
+    const aplicator = await this.aplicatorService.findAplicatorById(
+      this.createStockMovementDto.aplicatorId,
+    );
+    this.warehouseValidations.validateExistingWarehouse(warehouseOrigin);
+
+    await this.validateProductsInWarehouseDetail();
+    await this.updateWarehouseDetail();
+
+    return new StockMovement(
+      this.createStockMovementDto.description,
+      this.createStockMovementDto.value,
+      this.createStockMovementDto.movementType,
+      this.createStockMovementDto.stockMovementDetail,
+      this.createStockMovementDto.user,
+      this.createStockMovementDto.voucherDescription,
+      warehouseOrigin,
+      null,
+      batch,
+      aplicator,
+    );
+  }
+
+  async validateProductsInWarehouseDetail() {
+    const stockMovementDetails =
+      this.createStockMovementDto.stockMovementDetail;
+    this.warehouseDetailItems =
+      await this.warehouseDetailService.findManyByWarehouseId(
+        this.createStockMovementDto.warehouseOriginId,
+      );
+
+    for (const stockDetail of stockMovementDetails) {
+      const matchingWarehouseDetail = this.warehouseDetailItems.find(
+        (detail) => detail.productId === stockDetail.productId,
+      );
+
+      if (!matchingWarehouseDetail) {
+        throw new ProductNotFoundToAplicationException();
+      }
+
+      if (stockDetail.quantity > matchingWarehouseDetail.quantity) {
+        throw new InsufficientQuantityException();
+      }
+    }
+  }
+
+  async updateWarehouseDetail() {
+    const productDetails = this.createStockMovementDto.stockMovementDetail.map(
+      (detail) => ({
+        productId: detail.productId,
+        id: this.warehouseDetailItems.find(
+          (item) => item.productId === detail.productId,
+        )?.id,
+        quantity: detail.quantity,
+      }),
+    );
+
+    // Itera a través de productDetails y actualiza la cantidad para cada elemento
+    for (const productDetail of productDetails) {
+      if (
+        !(await this.warehouseDetailService.updateQuantity(
+          productDetail.id,
+          productDetail.quantity,
+        ))
+      )
+        throw new ProductNotFoundToAplicationException();
+    }
+  }
+}

--- a/src/Stock/application/factories/StockMovementGenerator.ts
+++ b/src/Stock/application/factories/StockMovementGenerator.ts
@@ -10,6 +10,7 @@ import WarehouseValidations from '../validations/WarehouseValidations';
 import ProductService from '../service/ProductService';
 import { Sell } from './States/Sell';
 import { Aplication } from './States/Aplication';
+import { Seeding } from './States/Seeding';
 import BatchService from '../service/BatchService';
 import AplicatorService from '../service/AplicatorService';
 
@@ -26,7 +27,7 @@ export class StockMovementGenerator {
 
   createMovement(
     createStockMovementDto: CreateStockMovementDto,
-  ): Buy | Sell | Aplication /*| Movement*/ {
+  ): Buy | Sell | Aplication | Seeding /*| Movement*/ {
     switch (createStockMovementDto.movementType) {
       case StockMovementType.BUY:
         return new Buy(
@@ -45,6 +46,15 @@ export class StockMovementGenerator {
         );
       case StockMovementType.APLICATION:
         return new Aplication(
+          createStockMovementDto,
+          this.warehouseService,
+          this.warehouseDetailService,
+          this.batchService,
+          this.aplicatorService,
+          this.warehouseValidations,
+        );
+      case StockMovementType.SEEDING:
+        return new Seeding(
           createStockMovementDto,
           this.warehouseService,
           this.warehouseDetailService,

--- a/src/Stock/domain/models/StockMovementType.ts
+++ b/src/Stock/domain/models/StockMovementType.ts
@@ -1,6 +1,7 @@
 enum StockMovementType {
   BUY = 'BUY',
   APLICATION = 'APLICATION',
+  SEEDING = 'SEEDING',
   SELL = 'SELL',
   MOVEMENT = 'MOVEMENT',
 }


### PR DESCRIPTION
## Summary
- support a new `SEEDING` state for stock movements
- wire up factories to create the new state

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684300c7ed48832084b6e7d18f244b1d